### PR TITLE
Make build-scripts build Jethro from its current sources

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -1,45 +1,109 @@
 #!/bin/bash -e
+#
+# OpenXT build script.
+# Software license: see accompanying LICENSE file.
+#
+# Contributions by Jean-Edouard Lejosne: Copyright (c) 2016 AIS.
+# Contributions by Christopher Clark: Copyright (c) 2016 BAE Systems
 
-DUDE=`whoami`
-DUDE_ID=`id -u ${DUDE}`
-IP_C=$(( 150 + ${DUDE_ID} % 100 ))
+# Invocation:
+# Takes a build identifier as an optional argument to the script
+# to enable rerunning this script to continue an interrupted build
+# or run a build with a specified directory name.
+
+# -- Script configuration settings.
+
+# This /16 subnet prefix is used for networking in the containers.
+# Strongly advised to use part of the private IP address space (eg. "192.168")
+# This value should be configured to match the setting used in setup.sh
+SUBNET_PREFIX="192.168"
+
+# -- End of script configuration settings.
+
+
+BUILD_USER="$(whoami)"
+BUILD_USER_ID="$(id -u ${BUILD_USER})"
+BUILD_USER_HOME="$(eval echo ~${BUILD_USER})"
+IP_C=$(( 150 + ${BUILD_USER_ID} % 100 ))
+ALL_BUILDS_SUBDIR_NAME="xt-builds"
+
+# Determine the intended build directory
+ALL_BUILDS_DIRECTORY="${BUILD_USER_HOME}/${ALL_BUILDS_SUBDIR_NAME}"
+if [ -z $1 ] ; then
+    BUILD_DIR_PREFIX=$(date +%y%m%d)
+
+#FIXME: the sorting in this isnt quite correct:
+    COUNTER=$(/bin/ls -1d "${ALL_BUILDS_DIRECTORY}/${BUILD_DIR_PREFIX}"-* \
+                      2>/dev/null | \
+              sort -nr | \
+              sed -e 's/^.*-//' -n  -e 1p)
+    COUNTER=$((COUNTER + 1))
+    BUILD_DIR="${BUILD_DIR_PREFIX}-${COUNTER}"
+else
+    BUILD_DIR="$1"
+fi
+
+BUILD_DIR_PATH="${ALL_BUILDS_DIRECTORY}/${BUILD_DIR}"
+if [ -e "$BUILD_DIR_PATH" ] ; then
+    echo "Build path is already present: ${BUILD_DIR_PATH}"
+fi
+if ! mkdir -p "${BUILD_DIR_PATH}" ; then
+    echo "Error: Failed to create build directory: ${BUILD_DIR_PATH}" >&2
+    exit 1
+fi
 
 # Fetch git mirrors
-for i in /home/git/${DUDE}/*.git; do
+for i in /home/git/${BUILD_USER}/*.git; do
     echo -n "Fetching `basename $i`: "
     cd $i
     git fetch --all > /dev/null 2>&1
     git log -1 --pretty='tformat:%H'
     cd - > /dev/null
-done | tee /tmp/git_heads_$DUDE
+done | tee /tmp/git_heads_$BUILD_USER
 
 # Start the git service if needed
 ps -p `cat /tmp/openxt_git.pid 2>/dev/null` >/dev/null 2>&1 || {
     rm -f /tmp/openxt_git.pid
-    git daemon --base-path=/home/git --pid-file=/tmp/openxt_git.pid --detach --syslog --export-all
+    git daemon --base-path=/home/git \
+               --pid-file=/tmp/openxt_git.pid \
+               --detach \
+               --syslog \
+               --export-all
     chmod 666 /tmp/openxt_git.pid
 }
 
-# Create a build dir
-BUILD_DIR=`date +%y%m%d`
-[ -d $BUILD_DIR ] && rm -ri $BUILD_DIR
-mkdir $BUILD_DIR
+echo "Running build: ${BUILD_DIR}"
 
 build_container() {
     NUMBER=$1           # 01
     NAME=$2             # oe
+    echo "Building container: ${NUMBER} : ${NAME}"
 
     # Start the OE container
-    sudo lxc-info -n ${DUDE}-${NAME} | grep STOPPED >/dev/null && sudo lxc-start -d -n ${DUDE}-${NAME}
+    sudo lxc-info -n ${BUILD_USER}-${NAME} | \
+        grep STOPPED >/dev/null && sudo lxc-start -d -n ${BUILD_USER}-${NAME}
 
     # Wait a few seconds and exit if the host doesn't respond
-    ping -c 1 192.168.${IP_C}.1${NUMBER} >/dev/null 2>&1 || ping -w 30 192.168.${IP_C}.1${NUMBER} >/dev/null 2>&1 || {
-	echo "Could not connect to openxt-${NAME}, exiting."
-	exit 1
+    CONTAINER_IP="${SUBNET_PREFIX}.${IP_C}.1${NUMBER}"
+    echo "Accessing container at network address: ${CONTAINER_IP}"
+
+    ping -c 1 ${CONTAINER_IP} >/dev/null 2>&1 || \
+        ping -w 30 ${CONTAINER_IP} >/dev/null 2>&1 || \
+    {
+        echo "Error: Could not connect to container ${BUILD_USER}-${NAME}" \
+             "at ${CONTAINER_IP}. Exiting." >&2
+        exit 2
     }
 
     # Build
-    cat $NAME/build.sh | sed -e "s|\%DUDE\%|${DUDE}|" -e "s|\%BUILD_DIR\%|${BUILD_DIR}|" -e "s|\%IP_C\%|${IP_C}|" | ssh -t -t -i ssh-key/openxt -oStrictHostKeyChecking=no build@192.168.${IP_C}.1${NUMBER}
+    cat $NAME/build.sh | \
+        sed -e "s|\%BUILD_USER\%|${BUILD_USER}|" \
+            -e "s|\%BUILD_DIR\%|${BUILD_DIR}|" \
+            -e "s|\%SUBNET_PREFIX\%|${SUBNET_PREFIX}|" \
+            -e "s|\%IP_C\%|${IP_C}|" \
+            -e "s|\%ALL_BUILDS_SUBDIR_NAME\%|${ALL_BUILDS_SUBDIR_NAME}|" |\
+        ssh -t -t -i "${BUILD_USER_HOME}"/ssh-key/openxt \
+            -oStrictHostKeyChecking=no build@${CONTAINER_IP}
 }
 
 build_container "01" "oe"

--- a/build-scripts/centos/build.sh
+++ b/build-scripts/centos/build.sh
@@ -2,15 +2,17 @@
 
 set -e
 
-DUDE=%DUDE%
+BUILD_USER=%BUILD_USER%
 BUILD_DIR=%BUILD_DIR%
 IP_C=%IP_C%
+SUBNET_PREFIX=%SUBNET_PREFIX%
+ALL_BUILDS_SUBDIR_NAME=%ALL_BUILDS_SUBDIR_NAME%
 
 # On first build, setup Oracle
 if [ ! -e ~/oracled ]; then
     while [ ! -f /tmp/oracle-xe-11.2.0-1.0.x86_64.rpm.zip ]; do
         echo "Please scp oracle-xe-11.2.0-1.0.x86_64.rpm.zip to my /tmp."
-        echo "  example: scp -i ssh-key/openxt oracle-xe-11.2.0-1.0.x86_64.rpm.zip build@192.168.${IP_C}.103:/tmp"
+        echo "  example: scp -i ssh-key/openxt oracle-xe-11.2.0-1.0.x86_64.rpm.zip build@${SUBNET_PREFIX}.${IP_C}.103:/tmp"
         sleep 60
     done
     unzip /tmp/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
@@ -74,7 +76,7 @@ cp openxt/out/* repo/RPMS
 createrepo repo
 
 # Copy the resulting repository
-scp -r repo ${DUDE}@192.168.${IP_C}.1:${BUILD_DIR}/rpms
+scp -r repo "${BUILD_USER}@${SUBNET_PREFIX}.${IP_C}.1:${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/rpms"
 
 # The script may run in an "ssh -t -t" environment, that won't exit on its own
 set +e

--- a/build-scripts/debian/build.sh
+++ b/build-scripts/debian/build.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-DUDE=%DUDE%
+BUILD_USER=%BUILD_USER%
 BUILD_DIR=%BUILD_DIR%
 IP_C=%IP_C%
+SUBNET_PREFIX=%SUBNET_PREFIX%
+ALL_BUILDS_SUBDIR_NAME=%ALL_BUILDS_SUBDIR_NAME%
 
 SBUILD="sbuild --purge-deps=never"
 
@@ -65,7 +67,7 @@ ls ../jessie/*.deb >/dev/null 2>&1 && reprepro includedeb jessie ../jessie/*.deb
 cd - >/dev/null
 
 # Copy the resulting repository
-scp -r repo ${DUDE}@192.168.${IP_C}.1:${BUILD_DIR}/debian
+scp -r repo "${BUILD_USER}@${SUBNET_PREFIX}.${IP_C}.1:${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/debian"
 
 # The script may run in an "ssh -t -t" environment, that won't exit on its own
 set +e

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -2,27 +2,60 @@
 
 set -e
 
-DUDE=%DUDE%
+BUILD_USER=%BUILD_USER%
 BUILD_DIR=%BUILD_DIR%
 IP_C=%IP_C%
+SUBNET_PREFIX=%SUBNET_PREFIX%
+ALL_BUILDS_SUBDIR_NAME=%ALL_BUILDS_SUBDIR_NAME%
 
 mkdir $BUILD_DIR
 cd $BUILD_DIR
-git clone git://192.168.${IP_C}.1/${DUDE}/openxt.git
+
+# commented out this usual clone line:
+#git clone git://${SUBNET_PREFIX}.${IP_C}.1/${BUILD_USER}/openxt.git
+
+# get the correct openxt.git repo for jethro
+# and merge the branch into master to use it.
+git clone https://github.com/aikidokatech/openxt.git
 cd openxt
+git checkout jethro-merge
+git checkout master
+git config user.email "build@localhost"
+git config user.name "automated build"
+git merge --no-edit jethro-merge
+
 cp example-config .config
 cat >>.config <<EOF
-OPENXT_GIT_MIRROR="192.168.${IP_C}.1/${DUDE}"
+OPENXT_GIT_MIRROR="${SUBNET_PREFIX}.${IP_C}.1/${BUILD_USER}"
 OPENXT_GIT_PROTOCOL="git"
 REPO_PROD_CACERT="/home/build/certs/prod-cacert.pem"
 REPO_DEV_CACERT="/home/build/certs/dev-cacert.pem"
 REPO_DEV_SIGNING_CERT="/home/build/certs/dev-cacert.pem"
 REPO_DEV_SIGNING_KEY="/home/build/certs/dev-cakey.pem"
 EOF
+
+./do_build.sh -s setupoe | tee setupoe.log
+
+# now remove setupoe from STEPS:
+sed -i 's/^STEPS="setupoe,/STEPS="/' ./do_build.sh
+
+# get the right jethro xenclient-oe repo
+# and again merge into master to use it
+cd build/repos/xenclient-oe
+git remote rm origin || echo ok no prior origin
+git remote add origin "https://github.com/aikidokatech/xenclient-oe.git"
+git fetch
+git checkout jethro-merge
+git checkout master
+git config user.email "build@localhost"
+git config user.name "automated build"
+git merge --no-edit jethro-merge
+cd -
+
 ./do_build.sh | tee build.log
 
 # Copy the build output
-scp -r build-output/* ${DUDE}@192.168.${IP_C}.1:${BUILD_DIR}/
+scp -r build-output/* "${BUILD_USER}@${SUBNET_PREFIX}.${IP_C}.1:${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/"
 
 # The script may run in an "ssh -t -t" environment, that won't exit on its own
 set +e

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -52,6 +52,9 @@ git config user.name "automated build"
 git merge --no-edit jethro-merge
 cd -
 
+# Apply Eric's temporary workaround:
+sed -i 's/^LOCALE_GENERATION_WITH_CROSS-LOCALEDEF = "1"/LOCALE_GENERATION_WITH_CROSS-LOCALEDEF = "0"/' ./build/repos/openembedded-core/meta/recipes-core/glibc/glibc-locale.inc
+
 ./do_build.sh | tee build.log
 
 # Copy the build output

--- a/build-scripts/oe/setup.sh
+++ b/build-scripts/oe/setup.sh
@@ -10,13 +10,29 @@ sed -i '/^start)$/a        mkdir -p /dev/shm/network/' /etc/init.d/networking
 PKGS=""
 PKGS="$PKGS openssh-server openssl"
 PKGS="$PKGS sed wget cvs subversion git-core coreutils unzip texi2html texinfo docbook-utils gawk python-pysqlite2 diffstat help2man make gcc build-essential g++ desktop-file-utils chrpath cpio" # OE main deps
-PKGS="$PKGS ghc guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip" # OpenXT-specific deps
+PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev" # OpenXT-specific deps
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.
 apt-get -y install $PKGS </dev/null || apt-get -y install $PKGS </dev/null
 
+# Download the GHC prerequisites from squeeze
+mkdir -p /tmp/ghc-prereq
+cd /tmp/ghc-prereq
+# FIXME: use the MIRROR
+wget http://http.us.debian.org/debian/pool/main/g/gmp/libgmpxx4ldbl_4.3.2+dfsg-1_i386.deb
+wget http://http.us.debian.org/debian/pool/main/g/gmp/libgmp3c2_4.3.2+dfsg-1_i386.deb
+wget http://http.us.debian.org/debian/pool/main/g/gmp/libgmp3-dev_4.3.2+dfsg-1_i386.deb
+dpkg -i libgmpxx4ldbl_4.3.2+dfsg-1_i386.deb libgmp3c2_4.3.2+dfsg-1_i386.deb libgmp3-dev_4.3.2+dfsg-1_i386.deb
+
+# Install the required version of GHC
+cd /tmp
+wget http://www.haskell.org/ghc/dist/6.12.3/ghc-6.12.3-i386-unknown-linux-n.tar.bz2
+tar jxf ghc-6.12.3-i386-unknown-linux-n.tar.bz2
+cd ghc-6.12.3
+./configure --prefix=/usr
+make install
+
 # Use bash instead of dash for /bin/sh
-mkdir -p /tmp
 echo "dash dash/sh boolean false" > /tmp/preseed.txt
 debconf-set-selections /tmp/preseed.txt
 dpkg-reconfigure -f noninteractive dash

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -189,7 +189,7 @@ EOF
 
 # Create a container for the main part of the OpenXT build
 setup_container "01" "oe" \
-                "debian" "${DEBIAN_MIRROR}" "--arch i386  --release squeeze"
+                "debian" "${DEBIAN_MIRROR}" "--arch i386  --release jessie"
 
 # Create a container for the Debian tool packages for OpenXT
 setup_container "02" "debian" \

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -1,86 +1,122 @@
 #!/bin/bash -e
+#
+# OpenXT setup script.
+# This script sets up the build host (just installs packages and adds a user),
+# and sets up LXC containers to build OpenXT.
+#
+# Software license: see accompanying LICENSE file.
+#
+# Contributions by Jean-Edouard Lejosne: Copyright (c) 2016 AIS.
+# Contributions by Christopher Clark: Copyright (c) 2016 BAE Systems.
 
-# This script sets up the host (just installs packages and adds a user),
-# and sets up LXC containers to build OpenXT
+# -- Script configuration settings.
 
-# The FQDN path for the Debian mirror (some chroots don't inherit the resolv.conf search domain)
-DEBIAN_MIRROR=http://httpredir.debian.org/debian
+# The FQDN path for the Debian mirror
+# (some chroots don't inherit the resolv.conf search domain)
+# eg. DEBIAN_MIRROR="http://httpredir.debian.org/debian"
+DEBIAN_MIRROR="http://httpredir.debian.org/debian"
 
-DUDE="openxt"
-if [ $# -ne 0 ]; then
-    if [ $# -ne 2 ] || [ $1 != "-u" ]; then
-	echo "Usage: ./setup.sh [-u user]"
-	exit 1
-    fi
-    DUDE=$2
+# This /16 subnet prefix is used for networking in the containers.
+# Strongly advised to use part of the private IP address space (eg. "192.168")
+SUBNET_PREFIX="192.168"
+
+# Ethernet mac address prefix for the container vnics. (eg. "00:FF:AA:42")
+MAC_PREFIX="00:FF:AA:42"
+
+# Teardown container on setup failure? 1: yes, anything-else: no.
+REMOVE_CONTAINER_ON_ERROR=1
+
+# -- End of script configuration settings.
+
+if [ "x${UID}" != "x0" ] ; then
+    echo "Error: This script needs to be run as root.">&2
+    exit 1
 fi
 
-# Install packages on the host, all at once to be faster
+BUILD_USER="openxt"
+if [ $# -ne 0 ]; then
+    if [ $# -ne 2 ] || [ $1 != "-u" ]; then
+        echo "Usage: $0 [-u user]"
+        exit 1
+    fi
+    BUILD_USER=$2
+fi
+
+# Ensure that all required packages are installed on this host.
+# When installing packages, do all at once to be faster.
 PKGS="lxc"
 #PKGS="$PKGS virtualbox" # Un-comment to setup a Windows VM
 PKGS="$PKGS bridge-utils libvirt-bin curl jq git sudo" # lxc and misc
 PKGS="$PKGS debootstrap" # Debian container
-PKGS="$PKGS librpm3 librpmbuild3 librpmio3 librpmsign1 libsqlite0 python-rpm python-sqlite python-sqlitecachec python-support python-urlgrabber rpm rpm-common rpm2cpio yum debootstrap bridge-utils" # Centos container
+PKGS="$PKGS librpm3 librpmbuild3 librpmio3 librpmsign1 libsqlite0 python-rpm \
+python-sqlite python-sqlitecachec python-support python-urlgrabber rpm \
+rpm-common rpm2cpio yum debootstrap bridge-utils" # Centos container
+
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.
 apt-get install $PKGS || apt-get install $PKGS
 
-# Create an openxt user on the host and make it a sudoer
-if [ ! `cut -d ":" -f 1 /etc/passwd | grep "^${DUDE}$"` ]; then
-    echo "Creating an openxt user for building, please choose a password."
-    adduser --gecos "" ${DUDE}
-    mkdir -p /home/${DUDE}/.ssh
-    touch /home/${DUDE}/.ssh/authorized_keys
-    touch /home/${DUDE}/.ssh/known_hosts
-    chown -R ${DUDE}:${DUDE} /home/${DUDE}/.ssh
-    echo "${DUDE}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
+# Ensure that the build user exists on the host and is a sudoer.
+if [ ! `cut -d ":" -f 1 /etc/passwd | grep "^${BUILD_USER}$"` ]; then
+    echo "Creating ${BUILD_USER} user for building, please choose a password."
+    adduser --gecos "" ${BUILD_USER}
+    BUILD_USER_HOME="$(eval echo ~${BUILD_USER})"
+    mkdir -p "${BUILD_USER_HOME}/.ssh"
+    touch "${BUILD_USER_HOME}"/.ssh/authorized_keys
+    touch "${BUILD_USER_HOME}"/.ssh/known_hosts
+    chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh
+    echo "${BUILD_USER}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
 else
-    if [ ! -f /home/${DUDE}/.ssh/authorized_keys ]; then
-	echo "${DUDE} doesn't have an SSH authorized_keys file, creating one."
-	mkdir -p /home/${DUDE}/.ssh
-	touch /home/${DUDE}/.ssh/authorized_keys
-	chown -R ${DUDE}:${DUDE} /home/${DUDE}/.ssh
+    BUILD_USER_HOME="$(eval echo ~${BUILD_USER})"
+    if [ ! -f "${BUILD_USER_HOME}"/.ssh/authorized_keys ]; then
+        echo "${BUILD_USER} has no SSH authorized_keys file, creating one."
+        mkdir -p "${BUILD_USER_HOME}"/.ssh
+        touch "${BUILD_USER_HOME}"/.ssh/authorized_keys
+        chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh
     fi
-    grep ${DUDE} /etc/sudoers >/dev/null 2>&1 || {
-	echo "${DUDE} is not a sudoer, adding him."
-	echo "${DUDE}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
+    grep ${BUILD_USER} /etc/sudoers >/dev/null 2>&1 || {
+        echo "${BUILD_USER} is not a sudoer, adding him."
+        echo "${BUILD_USER}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
     }
 fi
 
 # Create an SSH key for the user, to communicate with the containers
-if [ ! -d /home/${DUDE}/ssh-key ]; then
-    mkdir /home/${DUDE}/ssh-key
-    ssh-keygen -N "" -f /home/${DUDE}/ssh-key/openxt
-    chown -R ${DUDE}:${DUDE} /home/${DUDE}/ssh-key
+if [ ! -d "${BUILD_USER_HOME}"/ssh-key ]; then
+    mkdir "${BUILD_USER_HOME}"/ssh-key
+    ssh-keygen -N "" -f "${BUILD_USER_HOME}"/ssh-key/openxt
+    chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/ssh-key
 fi
 
-# Make up a network range 192.168.(150 + uid % 100).0
-# And a MAC range 00:FF:AA:42:(uid % 100):01
-DUDE_ID=`id -u ${DUDE}`
-IP_C=$(( 150 + ${DUDE_ID} % 100 ))
-MAC_E=$(( ${DUDE_ID} % 100 ))
+# Make up a network range ${SUBNET_PREFIX}.(150 + uid % 100).0
+# And a MAC range ${MAC_PREFIX}:(uid % 100):01
+BUILD_USER_ID=$(id -u ${BUILD_USER})
+IP_C=$(( 150 + ${BUILD_USER_ID} % 100 ))
+MAC_E=$(( ${BUILD_USER_ID} % 100 ))
+if [ "x${MAC_E}" == "x0" ] ; then
+    MAC_E="00"
+fi
 
 # Setup LXC networking on the host, to give known IPs to the containers
-if [ ! -f /etc/libvirt/qemu/networks/${DUDE}.xml ]; then
-    cat > /etc/libvirt/qemu/networks/${DUDE}.xml <<EOF
+if [ ! -f /etc/libvirt/qemu/networks/${BUILD_USER}.xml ]; then
+    cat > /etc/libvirt/qemu/networks/${BUILD_USER}.xml <<EOF
 <network>
-  <name>${DUDE}</name>
-  <bridge name="${DUDE}br0"/>
+  <name>${BUILD_USER}</name>
+  <bridge name="${BUILD_USER}br0"/>
   <forward/>
-  <ip address="192.168.${IP_C}.1" netmask="255.255.255.0">
+  <ip address="${SUBNET_PREFIX}.${IP_C}.1" netmask="255.255.255.0">
     <dhcp>
-      <range start="192.168.${IP_C}.2" end="192.168.${IP_C}.254"/>
-      <host mac="00:FF:AA:42:${MAC_E}:01" name="${DUDE}-oe"     ip="192.168.${IP_C}.101" />
-      <host mac="00:FF:AA:42:${MAC_E}:02" name="${DUDE}-debian" ip="192.168.${IP_C}.102" />
-      <host mac="00:FF:AA:42:${MAC_E}:03" name="${DUDE}-centos" ip="192.168.${IP_C}.103" />
+      <range start="${SUBNET_PREFIX}.${IP_C}.2" end="${SUBNET_PREFIX}.${IP_C}.254"/>
+      <host mac="${MAC_PREFIX}:${MAC_E}:01" name="${BUILD_USER}-oe"     ip="${SUBNET_PREFIX}.${IP_C}.101" />
+      <host mac="${MAC_PREFIX}:${MAC_E}:02" name="${BUILD_USER}-debian" ip="${SUBNET_PREFIX}.${IP_C}.102" />
+      <host mac="${MAC_PREFIX}:${MAC_E}:03" name="${BUILD_USER}-centos" ip="${SUBNET_PREFIX}.${IP_C}.103" />
     </dhcp>
   </ip>
 </network>
 EOF
     /etc/init.d/libvirtd restart
-    virsh net-autostart ${DUDE}
+    virsh net-autostart ${BUILD_USER}
 fi
-virsh net-start ${DUDE} >/dev/null 2>&1 || true
+virsh net-start ${BUILD_USER} >/dev/null 2>&1 || true
 
 LXC_PATH=`lxc-config lxc.lxcpath`
 
@@ -91,66 +127,98 @@ setup_container() {
     MIRROR=$4           # http://httpredir.debian.org/debian
     TEMPLATE_OPTIONS=$5 # --arch i386 --release squeeze
 
-    # Bail if the container already exists
-    if [ `lxc-ls | grep ${DUDE}-${NAME}` ]; then
-	echo "Container ${DUDE}-${NAME} already exists, skipping."
-	return
+    # Skip setup if the container already exists
+    if [ `lxc-ls | grep ${BUILD_USER}-${NAME}` ]; then
+        echo "Container ${BUILD_USER}-${NAME} already exists, skipping."
+        return
     fi
 
     # Create the container
     echo "Creating the ${NAME} container..."
-    MIRROR=${MIRROR} lxc-create -n ${DUDE}-${NAME} -t $TEMPLATE -- $TEMPLATE_OPTIONS
-    cat >> ${LXC_PATH}/${DUDE}-${NAME}/config <<EOF
+    MIRROR=${MIRROR} lxc-create -n "${BUILD_USER}-${NAME}" -t $TEMPLATE -- $TEMPLATE_OPTIONS
+    cat >> ${LXC_PATH}/${BUILD_USER}-${NAME}/config <<EOF
 lxc.network.type = veth
 lxc.network.flags = up
-lxc.network.link = ${DUDE}br0
-lxc.network.hwaddr = 00:FF:AA:42:${MAC_E}:${NUMBER}
+lxc.network.link = ${BUILD_USER}br0
+lxc.network.hwaddr = ${MAC_PREFIX}:${MAC_E}:${NUMBER}
 lxc.network.ipv4 = 0.0.0.0/24
 EOF
+
     echo "Configuring the ${NAME} container..."
-    #mount -o bind /dev ${LXC_PATH}/${DUDE}-${NAME}/rootfs/dev
-    cat ${NAME}/setup.sh | sed "s|\%MIRROR\%|${MIRROR}|" | chroot ${LXC_PATH}/${DUDE}-${NAME}/rootfs /bin/bash -e
-    #umount ${LXC_PATH}/${DUDE}-${NAME}/rootfs/dev
+    #mount -o bind /dev ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/dev
+
+    set +e
+    cat ${NAME}/setup.sh | \
+        sed "s|\%MIRROR\%|${MIRROR}|" | \
+        chroot ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs /bin/bash -e
+
+    # If the in-container setup script failed, check our configuration to see
+    # whether to destroy the container so that it can be recreated and setup
+    # reattempted when this script is rerun.
+    if [ $? != 0 ] ; then
+        echo "Failure executing in-container setup for ${NAME}. Abort.">&2
+        if [ "x${REMOVE_CONTAINER_ON_ERROR}" == "x1" ] ; then
+            lxc-destroy -n "${BUILD_USER}-${NAME}" || echo \
+                "Error tearing down container ${BUILD_USER}-${NAME}">&2
+        fi
+        exit 1
+    fi
+    set -e
+
+    #umount ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/dev
+
     # Allow the host to SSH to the container
-    cat /home/${DUDE}/ssh-key/openxt.pub >> ${LXC_PATH}/${DUDE}-${NAME}/rootfs/home/build/.ssh/authorized_keys
+    cat "${BUILD_USER_HOME}"/ssh-key/openxt.pub \
+        >> ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/home/build/.ssh/authorized_keys
+
     # Allow the container to SSH to the host
-    cat ${LXC_PATH}/${DUDE}-${NAME}/rootfs/home/build/.ssh/id_dsa.pub >> /home/${DUDE}/.ssh/authorized_keys
-    ssh-keyscan -H 192.168.${IP_C}.1 >> ${LXC_PATH}/${DUDE}-${NAME}/rootfs/home/build/.ssh/known_hosts
+    cat ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/home/build/.ssh/id_dsa.pub \
+        >> "${BUILD_USER_HOME}"/.ssh/authorized_keys
+
+    ssh-keyscan -H ${SUBNET_PREFIX}.${IP_C}.1 \
+        >> ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/home/build/.ssh/known_hosts
 
     # Copy the build script for that container to the user home directory
-    mkdir -p /home/${DUDE}/${NAME}
-    cp ${NAME}/build.sh /home/${DUDE}/${NAME}/
-    chown -R ${DUDE}:${DUDE} /home/${DUDE}/${NAME}
+    mkdir -p "${BUILD_USER_HOME}"/${NAME}
+    cp ${NAME}/build.sh "${BUILD_USER_HOME}"/${NAME}/
+    chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/${NAME}
 
     # Copy resolv.conf over for networking, shouldn't be needed
-    #cp /etc/resolv.conf ${LXC_PATH}/${DUDE}-${NAME}/rootfs/etc/resolv.conf
+    #cp /etc/resolv.conf ${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs/etc/resolv.conf
 }
 
 # Create a container for the main part of the OpenXT build
-setup_container "01" "oe"     "debian" "${DEBIAN_MIRROR}" "--arch i386  --release squeeze"
+setup_container "01" "oe" \
+                "debian" "${DEBIAN_MIRROR}" "--arch i386  --release squeeze"
 
 # Create a container for the Debian tool packages for OpenXT
-setup_container "02" "debian" "debian" "${DEBIAN_MIRROR}" "--arch amd64 --release jessie"
+setup_container "02" "debian" \
+                "debian" "${DEBIAN_MIRROR}" "--arch amd64 --release jessie"
 
 # Create a container for the Centos tool packages for OpenXT
-setup_container "03" "centos" "centos" "" "--arch x86_64 --release 7"
+setup_container "03" "centos" \
+                "centos" "" "--arch x86_64 --release 7"
 
-# Setup a mirror of the git repositories, for the build to be consistant (and slightly faster)
+# Setup a mirror of the git repositories for the build to be consistent
+# (and slightly faster)
 if [ ! -d /home/git ]; then
     mkdir /home/git
     chown nobody:nogroup /home/git
     chmod 777 /home/git
 fi
-if [ ! -d /home/git/${DUDE} ]; then
-    mkdir -p /home/git/${DUDE}
-    cd /home/git/${DUDE}
-    for repo in `curl -s "https://api.github.com/orgs/OpenXT/repos?per_page=100" | jq '.[].name' | cut -d '"' -f 2 | sort -u`; do
-	git clone --mirror https://github.com/OpenXT/${repo}.git
+if [ ! -d /home/git/${BUILD_USER} ]; then
+    mkdir -p /home/git/${BUILD_USER}
+    cd /home/git/${BUILD_USER}
+    for repo in \
+        $(curl -s "https://api.github.com/orgs/OpenXT/repos?per_page=100" | \
+          jq '.[].name' | cut -d '"' -f 2 | sort -u)
+    do
+        git clone --mirror https://github.com/OpenXT/${repo}.git
     done
     cd - > /dev/null
-    chown -R ${DUDE}:${DUDE} /home/git/${DUDE}
+    chown -R ${BUILD_USER}:${BUILD_USER} /home/git/${BUILD_USER}
 fi
 
-cp build.sh /home/${DUDE}
-chown ${DUDE}:${DUDE} /home/${DUDE}/build.sh
-echo "Done! Now login as ${DUDE} and run ./build.sh to start a build."
+cp -f build.sh "${BUILD_USER_HOME}/"
+chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/build.sh
+echo "Done! Now login as ${BUILD_USER} and run ~/build.sh to start a build."


### PR DESCRIPTION
Two commits here touch a lot of the build-scripts to do general improvements and switch the build to generate the Jethro branch in a jessie container. In order to make it work with the current state of the trees, there is some code in oe/build.sh that should be removed once the Jethro merge to master has been completed.

I'm of the opinion that it is more urgent to get a simple way to get a correct build (ie. take this change and publicize it) than to wait for people to get Jethro builds working without this, and then wait for the master merge and so avoid taking these short-term jethro branch warts in oe/build.sh.

There is work in here in the direction of enabling continuation of an interrupted build. That is not yet complete but the changes so far are sensible on their own anyway.

Note that these changes are not organized as individual cherry-pickable features.

Christopher
